### PR TITLE
Add normalisation method option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ files:
 
 experiment:
   hv_barrier: 25                                              # Electric field barrier for electron spectrum. Nothing will be plotted under this value.
-  normalise_spectra: true                                     # Normalisation through comparison of exp/ sim gamma peak areas. 
+  normalise_spectra: true                                     # Apply normalisation to simulated spectra.
+  normalisation_method: recoil                                # Options: recoil, gamma_peak, electron_area
   show_exp_spectra: true
   elec_eff_params: [1.273, -1.541, -0.943, -0.128, -0.00137]
   gam_eff_params: [1.866, -0.627, -0.201, 0.246, -0.0779]

--- a/configs/249Md.yaml
+++ b/configs/249Md.yaml
@@ -18,6 +18,7 @@ files:
 experiment:
  hv_barrier: 25
  normalise_spectra: true
+ normalisation_method: recoil
  show_exp_spectra: true
  elec_eff_params: [1.273, -1.541, -0.943, -0.128, -0.00137]
  gam_eff_params: [1.866, -0.627, -0.201, 0.246, -0.0779]

--- a/configs/250Fm.yaml
+++ b/configs/250Fm.yaml
@@ -18,6 +18,7 @@ files:
 experiment:
  hv_barrier: 25
  normalise_spectra: true
+ normalisation_method: recoil
  show_exp_spectra: true
  elec_eff_params: [1.273, -1.541, -0.943, -0.128, -0.00137]
  gam_eff_params: [1.866, -0.627, -0.201, 0.246, -0.0779]

--- a/configs/254No.yaml
+++ b/configs/254No.yaml
@@ -18,6 +18,7 @@ files:
 experiment:
  hv_barrier: 38
  normalise_spectra: true
+ normalisation_method: recoil
  show_exp_spectra: true
  elec_eff_params: [1.273, -1.541, -0.943, -0.128, -0.00137]
  gam_eff_params: [1.866, -0.627, -0.201, 0.246, -0.0779]

--- a/src/sim.py
+++ b/src/sim.py
@@ -94,6 +94,7 @@ def main():
         gamma_range=config['nucleus']['gamma_range'],
         show_exp_spectra=config['experiment']['show_exp_spectra'],
         normalise_simulated_spectra=config['experiment']['normalise_spectra'],
+        normalisation_method=config['experiment'].get('normalisation_method', 'recoil'),
         total_recoils=config['nucleus']['total_recoils'],
         theory_gR_vals=config['theory']['gR_vals'],
         theory_gK_vals=config['theory']['gK_vals']


### PR DESCRIPTION
## Summary
- allow YAML config to choose gamma, electron-area, or recoil normalisation
- document the new `normalisation_method` option
- pass the method through `sim.py`
- implement logic for the new methods in `plot_combined_spectra`

## Testing
- `python -m py_compile src/utils.py src/sim.py`

------
https://chatgpt.com/codex/tasks/task_e_685421058b808331a51f13dbdb35ab6a